### PR TITLE
New options: `--file`, `--edit` and `--print-cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "clap",
  "console_error_panic_hook",
  "getrandom",
+ "hcl-rs",
  "pretty_assertions",
  "rust-embed",
  "serde",
@@ -443,6 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +655,52 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hcl-edit"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f32dc8e2ac2efd3726a759c0e1cd91315465d75a191468dcd8f885f384cad0"
+dependencies = [
+ "fnv",
+ "hcl-primitives",
+ "pratt",
+ "vecmap-rs",
+ "winnow",
+]
+
+[[package]]
+name = "hcl-primitives"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f097693bfc799cc5043956e93a28c51ca4e72f2c3daa21f65a5b0a28510df1f2"
+dependencies = [
+ "itoa",
+ "kstring",
+ "ryu",
+ "serde",
+ "unicode-ident",
+]
+
+[[package]]
+name = "hcl-rs"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87112599bbc3476dc61061583cc6c0d4f305f0820d4cf3e4cda46199248dd781"
+dependencies = [
+ "hcl-edit",
+ "hcl-primitives",
+ "indexmap",
+ "itoa",
+ "serde",
+ "vecmap-rs",
 ]
 
 [[package]]
@@ -887,6 +940,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +986,16 @@ checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1159,6 +1233,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "pratt"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e0a4425d076f0718b820673a38fbf3747080c61017eeb0dd79bc7e472b8bb8"
 
 [[package]]
 name = "pretty_assertions"
@@ -1493,6 +1573,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1915,6 +2001,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vecmap-rs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cfc542f75493f412a51c02af26f58f710ab0e2204d264135054377244276be"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2293,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,7 @@ dependencies = [
  "chrono",
  "clap",
  "console_error_panic_hook",
+ "edit",
  "getrandom",
  "hcl-rs",
  "pretty_assertions",
@@ -444,6 +445,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
+name = "edit"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f364860e764787163c8c8f58231003839be31276e821e2ad2092ddf496b1aa09"
+dependencies = [
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +725,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -1009,6 +1035,12 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1394,6 +1426,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -1401,7 +1446,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1626,7 +1671,7 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -2142,6 +2187,18 @@ checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ async-trait = "0.1.89"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 hcl-rs = "0.19.2"
+edit = "0.1.5"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 rust-embed = { version = "8.7.2", features = ["debug-embed"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ async-trait = "0.1.89"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 hcl-rs = "0.19.2"
-edit = "0.1.5"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 rust-embed = { version = "8.7.2", features = ["debug-embed"] }
@@ -51,6 +50,7 @@ tokio = { version = "1.45.1" }
 typespec_client_core = { version = "0.7.0", features = ["tokio"] }
 uuid = { version = "1", features = ["v4"] }
 rust-embed = { version = "8.7.2", features = ["debug-embed"], optional = true }
+edit = "0.1.5"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ async-trait = "0.1.89"
 
 tracing = "0.1"
 tracing-subscriber = "0.3"
+hcl-rs = "0.19.2"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 rust-embed = { version = "8.7.2", features = ["debug-embed"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,6 @@
 use metadata_index::Index;
 use std::path::PathBuf;
+pub mod cli_expander;
 pub mod invoke;
 pub mod metadata_command;
 pub mod metadata_index;

--- a/src/api/cli_expander.rs
+++ b/src/api/cli_expander.rs
@@ -1,26 +1,239 @@
-use super::metadata_command::Operation;
-use anyhow::Result;
+use std::str::FromStr;
+
+use super::metadata_command::ArgGroup;
+use anyhow::{anyhow, bail, Context, Result};
+use clap::builder::PossibleValue;
 
 pub struct CLIExpander {
-    operation: Operation,
+    shell: Shell,
+    arg_groups: Vec<ArgGroup>,
     raw_input: Vec<String>,
     body: Option<serde_json::Value>,
 }
 
 impl CLIExpander {
     pub fn new(
-        operation: &Operation,
+        shell: &Shell,
+        arg_groups: &Vec<ArgGroup>,
         raw_input: &Vec<String>,
         body: Option<serde_json::Value>,
     ) -> Self {
         Self {
-            operation: operation.clone(),
+            shell: shell.clone(),
+            arg_groups: arg_groups.clone(),
             raw_input: raw_input.clone(),
             body,
         }
     }
 
     pub fn expand(&self) -> Result<String> {
-        todo!();
+        let mut cli_inputs = vec![];
+        let mut it = self.raw_input.iter();
+        while let Some(opt) = it.next() {
+            if *opt == "--print-cli" {
+                it.next();
+                continue;
+            }
+            if opt.starts_with("--print-cli=") {
+                continue;
+            }
+
+            if *opt == "--edit" || *opt == "-e" {
+                continue;
+            }
+
+            if *opt == "--file" || *opt == "-f" {
+                it.next();
+                continue;
+            }
+            if opt.starts_with("--file=") || opt.starts_with("-f=") {
+                continue;
+            }
+
+            cli_inputs.push(opt.clone());
+        }
+
+        if let Some(ref body) = self.body {
+            // Expand the root level parameters (except "properties"), plus the top level properties of the "properties".
+            self.arg_groups
+                .iter()
+                .skip_while(|ag| ag.name.is_empty())
+                .for_each(|ag| {
+                    ag.args.iter().for_each(|arg| {
+                        if arg.var.starts_with("$parameters.") {
+                            let paths: Vec<_> = arg
+                                .var
+                                .strip_prefix("$parameters.")
+                                .unwrap()
+                                .split('.')
+                                .collect();
+
+                            if let Ok(val) = self.find_value(&paths, body) {
+                                if let Some(option_name) = arg.options.first() {
+                                    let prefix = if option_name.len() == 1 { "-" } else { "--" };
+                                    cli_inputs.push(format!("{prefix}{}", option_name.clone()));
+                                    cli_inputs.push(self.shell.escape(&val.to_string()));
+                                }
+                            }
+                        }
+                    });
+                });
+        }
+        Ok(cli_inputs.join(" "))
+    }
+
+    fn find_value<'a>(
+        &'a self,
+        paths: &Vec<&str>,
+        val: &'a serde_json::Value,
+    ) -> Result<&'a serde_json::Value> {
+        let mut val = val;
+        for path in paths {
+            match val {
+                serde_json::Value::Null
+                | serde_json::Value::Bool(_)
+                | serde_json::Value::Number(_)
+                | serde_json::Value::String(_) => {
+                    bail!("looking up the field {path} on {val:?}");
+                }
+                serde_json::Value::Array(values) => {
+                    let idx: usize = path.parse().context(format!(
+                        "looking up the field {path} on an array: {values:?}"
+                    ))?;
+                    val = values.get(idx).context(format!(
+                        "getting the {idx}-th element on the array: {values:?}"
+                    ))?;
+                }
+                serde_json::Value::Object(map) => {
+                    val = map
+                        .get(*path)
+                        .context(format!("looking up the field {path} on an object {map:?}"))?;
+                }
+            }
+        }
+        return Ok(val);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Shell {
+    Cmd,
+    PowerShell,
+    Unix,
+}
+
+impl Shell {
+    pub fn variants() -> impl Iterator<Item = PossibleValue> {
+        [
+            PossibleValue::new("cmd"),
+            PossibleValue::new("powershell"),
+            PossibleValue::new("unix"),
+        ]
+        .into_iter()
+    }
+
+    fn escape(&self, arg: &str) -> String {
+        match self {
+            Shell::Unix => {
+                let mut out = String::from(r#"""#);
+                for c in arg.chars() {
+                    if c == '"' {
+                        out.push('\\'); // escape `"` by `\"`
+                    }
+                    out.push(c);
+                }
+                out.push('"');
+                out
+            }
+            Shell::PowerShell | Shell::Cmd => {
+                let mut out = String::from(r#"""#);
+                for c in arg.chars() {
+                    if c == '"' {
+                        out.push('"'); // escape `"` by `""`
+                    }
+                    out.push(c);
+                }
+                out.push('"');
+                out
+            }
+        }
+    }
+}
+
+impl FromStr for Shell {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "cmd" => Ok(Shell::Cmd),
+            "powershell" => Ok(Shell::PowerShell),
+            "unix" => Ok(Shell::Unix),
+            _ => Err(anyhow!("invalid shell: {s}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unix_escape_simple() {
+        assert_eq!(Shell::Unix.escape("foo"), r#""foo""#);
+    }
+
+    #[test]
+    fn test_unix_escape_with_space() {
+        assert_eq!(Shell::Unix.escape("foo bar"), r#""foo bar""#);
+    }
+
+    #[test]
+    fn test_unix_escape_with_quote() {
+        assert_eq!(Shell::Unix.escape("foo'bar"), r#""foo'bar""#);
+    }
+
+    #[test]
+    fn test_unix_escape_with_double_quote() {
+        assert_eq!(Shell::Unix.escape(r#"foo"bar"#), r#""foo\"bar""#);
+    }
+
+    #[test]
+    fn test_cmd_escape_simple() {
+        assert_eq!(Shell::Cmd.escape("foo"), r#""foo""#);
+    }
+
+    #[test]
+    fn test_cmd_escape_with_space() {
+        assert_eq!(Shell::Cmd.escape("foo bar"), r#""foo bar""#);
+    }
+
+    #[test]
+    fn test_cmd_escape_with_quote() {
+        assert_eq!(Shell::Cmd.escape("foo'bar"), r#""foo'bar""#);
+    }
+
+    #[test]
+    fn test_cmd_escape_with_double_quote() {
+        assert_eq!(Shell::Cmd.escape(r#"foo"bar"#), r#""foo""bar""#);
+    }
+
+    #[test]
+    fn test_powershell_escape_simple() {
+        assert_eq!(Shell::PowerShell.escape("foo"), r#""foo""#);
+    }
+
+    #[test]
+    fn test_powershell_escape_with_space() {
+        assert_eq!(Shell::PowerShell.escape("foo bar"), r#""foo bar""#);
+    }
+
+    #[test]
+    fn test_powershell_escape_with_quote() {
+        assert_eq!(Shell::PowerShell.escape("foo'bar"), r#""foo'bar""#);
+    }
+
+    #[test]
+    fn test_powershell_escape_with_double_quote() {
+        assert_eq!(Shell::PowerShell.escape(r#"foo"bar"#), r#""foo""bar""#);
     }
 }

--- a/src/api/cli_expander.rs
+++ b/src/api/cli_expander.rs
@@ -1,0 +1,26 @@
+use super::metadata_command::Operation;
+use anyhow::Result;
+
+pub struct CLIExpander {
+    operation: Operation,
+    raw_input: Vec<String>,
+    body: Option<serde_json::Value>,
+}
+
+impl CLIExpander {
+    pub fn new(
+        operation: &Operation,
+        raw_input: &Vec<String>,
+        body: Option<serde_json::Value>,
+    ) -> Self {
+        Self {
+            operation: operation.clone(),
+            raw_input: raw_input.clone(),
+            body,
+        }
+    }
+
+    pub fn expand(&self) -> Result<String> {
+        todo!();
+    }
+}

--- a/src/api/invoke.rs
+++ b/src/api/invoke.rs
@@ -1,101 +1,21 @@
+use super::metadata_command::{Operation, Schema};
+use anyhow::{bail, Result};
+use clap::ArgMatches;
 use core::unreachable;
 use std::collections::HashMap;
 
-use crate::client::Client;
-
-use super::metadata_command::{
-    Command, ConditionOperator, ConditionOperatorType, Operation, Schema,
-};
-use anyhow::{anyhow, bail, Result};
-use clap::ArgMatches;
-
-pub struct CommandInvocation {
-    command: Command,
-    matches: ArgMatches,
-    body: Option<bytes::Bytes>,
-}
-
-impl CommandInvocation {
-    pub fn new(
-        command: &Command,
-        matches: &ArgMatches,
-        body: Option<bytes::Bytes>,
-    ) -> Result<Self> {
-        Ok(Self {
-            command: command.clone(),
-            matches: matches.clone(),
-            body,
-        })
-    }
-
-    pub async fn invoke(&self, client: &Client) -> Result<String> {
-        let operation = self
-            .select_operation()
-            .ok_or(anyhow!("no operation is selected"))?;
-        let operation_ionvocation = OperationInvocation::new(operation, &self.matches, &self.body);
-        operation_ionvocation.invoke(client).await
-    }
-
-    fn select_operation(&self) -> Option<&Operation> {
-        if self.command.conditions.is_none() {
-            return self.command.operations.first();
-        }
-
-        let matched_condition = self
-            .command
-            .conditions
-            .as_ref()
-            .unwrap()
-            .iter()
-            .find(|&c| self.match_operator(&c.operator))
-            .map(|c| c.var.clone())?;
-
-        self.command.operations.iter().find(|op| {
-            op.when
-                .clone()
-                .unwrap_or(vec![])
-                .iter()
-                .any(|w| w == &matched_condition)
-        })
-    }
-
-    fn match_operator(&self, operator: &ConditionOperator) -> bool {
-        match operator {
-            ConditionOperator::Operators { operators, type_ } => match type_ {
-                ConditionOperatorType::Not | ConditionOperatorType::HasValue => unreachable!(
-                    r#"operators' condition type can only be "and" or "or", got=%{type_:?}"#
-                ),
-                ConditionOperatorType::And => operators.iter().all(|o| self.match_operator(o)),
-                ConditionOperatorType::Or => operators.iter().any(|o| self.match_operator(o)),
-            },
-            ConditionOperator::Operator { operator, type_ } => match type_ {
-                ConditionOperatorType::Not => !self.match_operator(operator),
-                ConditionOperatorType::HasValue
-                | ConditionOperatorType::And
-                | ConditionOperatorType::Or => {
-                    unreachable!(r#"operators' condition type can only be "not", got=%{type_:?}"#)
-                }
-            },
-            ConditionOperator::Arg { arg, type_ } => match type_ {
-                ConditionOperatorType::HasValue => self.matches.get_raw(arg).is_some(),
-                ConditionOperatorType::Not
-                | ConditionOperatorType::And
-                | ConditionOperatorType::Or => unreachable!(
-                    r#"operators' condition type can only be "hasValue", got=%{type_:?}"#
-                ),
-            },
-        }
-    }
-}
-
-struct OperationInvocation {
+pub struct OperationInvocation {
     operation: Operation,
     matches: ArgMatches,
-    body: Option<bytes::Bytes>,
+    body: Option<serde_json::Value>,
 }
 
 impl OperationInvocation {
-    pub fn new(operation: &Operation, matches: &ArgMatches, body: &Option<bytes::Bytes>) -> Self {
+    pub fn new(
+        operation: &Operation,
+        matches: &ArgMatches,
+        body: &Option<serde_json::Value>,
+    ) -> Self {
         Self {
             operation: operation.clone(),
             matches: matches.clone(),
@@ -103,7 +23,7 @@ impl OperationInvocation {
         }
     }
 
-    async fn invoke(&self, client: &crate::client::Client) -> Result<String> {
+    pub async fn invoke(&self, client: &crate::client::Client) -> Result<String> {
         if self.operation.http.is_none() {
             bail!(
                 r#"HTTP information not found for operation "{}""#,
@@ -134,18 +54,18 @@ impl OperationInvocation {
             query_pairs.insert(param.name.clone(), param.default.value.clone());
         }
 
-        let body: Option<bytes::Bytes> = if self.body.is_some() {
+        let body = if self.body.is_some() {
             self.body.clone()
         } else if let Some(body_meta) = &http.request.body {
             if let Some(schema) = &body_meta.json.schema {
                 self.build_body(schema.clone())?
-                    .map(|v| bytes::Bytes::from(v.to_string()))
             } else {
                 None
             }
         } else {
             None
-        };
+        }
+        .map(|v| bytes::Bytes::from(v.to_string()));
 
         let response = client
             .run(

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -220,7 +220,7 @@ fn build_args(versions: &Vec<String>, command: &metadata_command::Command) -> Ve
         Arg::new("print-cli")
             .long("print-cli")
             .value_parser(PossibleValuesParser::new(Shell::variants()))
-            .help(r#"Print the equivalent CLI command that reproduces the request built from "--edit" or "--file" input, instead of executing it"#),
+            .help(r#"Print the equivalent CLI command built from "--edit" or "--file", instead of executing it"#),
     );
 
     // Build the remaining arguments based on the command metadata.

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::api::cli_expander::Shell;
 use crate::api::{metadata_command, metadata_index, ApiManager};
 use crate::arg::CliInput;
 use clap::builder::PossibleValuesParser;
@@ -218,7 +219,7 @@ fn build_args(versions: &Vec<String>, command: &metadata_command::Command) -> Ve
     out.push(
         Arg::new("print-cli")
             .long("print-cli")
-            .action(clap::ArgAction::SetTrue)
+            .value_parser(PossibleValuesParser::new(Shell::variants()))
             .help(r#"Print the equivalent CLI command that reproduces the request built from "--edit" or "--file" input, instead of executing it"#),
     );
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -197,12 +197,23 @@ fn build_args(versions: &Vec<String>, command: &metadata_command::Command) -> Ve
             .value_parser(PossibleValuesParser::new(versions)),
     );
 
-    // Build the input arg
+    // Build the file & edit args
     out.push(
-        Arg::new("input")
-            .long("input")
-            .short('i')
-            .help("Path to the input file"),
+        Arg::new("file")
+            .long("file")
+            .short('f')
+            .value_name("PATH")
+            .value_parser(clap::value_parser!(std::path::PathBuf))
+            .conflicts_with("edit")
+            .help("Read request payload from the file"),
+    );
+    out.push(
+        Arg::new("edit")
+            .long("edit")
+            .short('e')
+            .action(clap::ArgAction::SetTrue)
+            .conflicts_with("file")
+            .help("Open default editor to compose request payload"),
     );
 
     // Build the remaining arguments based on the command metadata.

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -220,7 +220,7 @@ fn build_args(versions: &Vec<String>, command: &metadata_command::Command) -> Ve
         Arg::new("print-cli")
             .long("print-cli")
             .value_parser(PossibleValuesParser::new(Shell::variants()))
-            .help(r#"Print the equivalent CLI command built from "--edit" or "--file", instead of executing it"#),
+            .help(r#"Print the equivalent CLI command instead of executing it, useful when combined with `--file` or `--edit`"#),
     );
 
     // Build the remaining arguments based on the command metadata.

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -197,7 +197,16 @@ fn build_args(versions: &Vec<String>, command: &metadata_command::Command) -> Ve
             .value_parser(PossibleValuesParser::new(versions)),
     );
 
-    // Only the default argument group (which contains the path segments) will be considered for required or not.
+    // Build the input arg
+    out.push(
+        Arg::new("input")
+            .long("input")
+            .short('i')
+            .help("Path to the input file"),
+    );
+
+    // Build the remaining arguments based on the command metadata.
+    // NOTE: Only the default argument group (which contains the path segments) will be considered for required or not.
     command
         .arg_groups
         .iter()

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -215,8 +215,15 @@ fn build_args(versions: &Vec<String>, command: &metadata_command::Command) -> Ve
             .conflicts_with("file")
             .help("Open default editor to compose request payload"),
     );
+    out.push(
+        Arg::new("print-cli")
+            .long("print-cli")
+            .action(clap::ArgAction::SetTrue)
+            .help(r#"Print the equivalent CLI command that reproduces the request built from "--edit" or "--file" input, instead of executing it"#),
+    );
 
     // Build the remaining arguments based on the command metadata.
+    // NOTE: Only the top level arg groups are exposed.
     // NOTE: Only the default argument group (which contains the path segments) will be considered for required or not.
     command
         .arg_groups

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,8 @@ fn get_matches(cmd: Command, input: Vec<String>) -> Result<ArgMatches> {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn get_file(p: &PathBuf) -> Result<String> {
-    bail!(r#""--file" is not supported on wasm32"#);
+fn get_file(_: &PathBuf) -> Result<String> {
+    Err(anyhow!(r#""--file" is not supported on wasm32"#))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -116,14 +116,8 @@ fn get_file(p: &PathBuf) -> Result<String> {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-extern "C" {
-    pub fn edit_js(content: &str) -> &str;
-}
-
-#[cfg(target_arch = "wasm32")]
-fn edit(content: String) -> Result<String> {
-    Ok(edit_js(&content).to_string())
+fn edit(_: String) -> Result<String> {
+    Err(anyhow!(r#""--edit" is not supported on wasm32"#))
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@ where
             }
 
             let mut body = None;
-            if let Some(p) = matches.get_one::<String>("input") {
-                body = Some(get_input(p.as_str())?);
+            if let Some(p) = matches.get_one::<PathBuf>("file") {
+                body = Some(get_file(&p)?);
             }
             let invoker = CommandInvocation::new(&cmd_metadata, &matches, body)?;
 
@@ -79,14 +79,14 @@ pub fn get_matches(cmd: Command, input: Vec<String>) -> Result<ArgMatches> {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub fn get_input(p: PathBuf) -> Result<bytes::Bytes> {
-    bail!(r#""--input" is not supported on wasm32"#);
+pub fn get_file(p: &PathBuf) -> Result<bytes::Bytes> {
+    bail!(r#""--file" is not supported on wasm32"#);
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn get_input(p: &str) -> Result<bytes::Bytes> {
-    let input = std::fs::read_to_string(p).context("reading the input from {p}")?;
-    let body = hcl::parse(&input).context("parsing the input as HCL")?;
+pub fn get_file(p: &PathBuf) -> Result<bytes::Bytes> {
+    let input = std::fs::read_to_string(p).context("reading file from {p}")?;
+    let body = hcl::parse(&input).context("parsing the file as HCL")?;
     let v: serde_json::Value = hcl::from_body(body)?;
     Ok(bytes::Bytes::from(v.to_string()))
 }


### PR DESCRIPTION
This PR supports a couple of options to enrich the user experience:

- `--file`: Read the request payload from a HCL file
- `--edit`: Open the default editor to compose the request payload
- `--print-cli`: Print the equivalent CLI command built from "--edit" or "--file", instead of executing it